### PR TITLE
add do-not-upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pacifica CLI Uploader
 
-[![Build Status](https://travis-ci.org/pacifica/pacifica-cli-uploader.svg?branch=master)](https://travis-ci.org/pacifica/pacifica-cli)
+[![Build Status](https://travis-ci.org/pacifica/pacifica-cli.svg?branch=master)](https://travis-ci.org/pacifica/pacifica-cli)
 [![Build Status](https://ci.appveyor.com/api/projects/status/0ddinx1bdfroptf7?svg=true)](https://ci.appveyor.com/project/dmlb2000/pacifica-cli)
 [![Code Climate](https://codeclimate.com/github/pacifica/pacifica-cli/badges/gpa.svg)](https://codeclimate.com/github/pacifica/pacifica-cli)
 [![Issue Count](https://codeclimate.com/github/pacifica/pacifica-cli/badges/issue_count.svg)](https://codeclimate.com/github/pacifica/pacifica-cli)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ before_test:
     $env:INGEST_CONFIG = "$PWD/travis/ingest/config.cfg";
     $env:INGEST_CPCONFIG = "$PWD/travis/ingest/server.conf";
     Start-Process C:\pacifica\Scripts\pacifica-ingest.exe;
-    Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.ingest.tasks worker --loglevel=info -P eventlet";
+    Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.ingest.tasks worker --loglevel=info -P solo -c 1" -RedirectStandardOutput celery-output.log -RedirectStandardError celery-error.log;
     $MD_VERSION = `pip show pacifica-metadata | grep Version: | awk '{ print $2 }';
     Invoke-WebRequest https://github.com/pacifica/pacifica-metadata/archive/v${MD_VERSION}.zip -OutFile pacifica-metadata.zip;
     Expand-Archive pacifica-metadata.zip -DestinationPath C:\pacifica-metadata;
@@ -55,6 +55,11 @@ before_test:
     Start-Process C:\pacifica\Scripts\pacifica-policy.exe -RedirectStandardError policy-error.log -RedirectStandardOutput policy-output.log;
     sleep 3;
     Invoke-WebRequest http://127.0.0.1:8181/status/users/search/dmlb2001/simple -TimeoutSec 1800;
+    Invoke-WebRequest 'http://127.0.0.1:8066/get_state?job_id=1234';
+    Invoke-WebRequest 'http://127.0.0.1:8051/getid?range=42&mode=test_mode';
+    Invoke-WebRequest http://127.0.0.1:8080/1234;
+    Get-Content celery-output.log; Get-Content celery-error.log;
+    echo "Done!";
 
 install:
 - ps: >
@@ -66,7 +71,7 @@ install:
     C:\pacifica\Scripts\activate.ps1;
     python -m pip install pip setuptools wheel --upgrade;
     pip install -r requirements-dev.txt;
-    pip install celery[redis] eventlet;
+    pip install celery[redis] 'redis<3.0';
 
 build: off
 
@@ -107,6 +112,7 @@ test_script:
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload travis;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --tar-in-tar README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-save retry.tar README.md;
+    coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-save retry.tar --do-not-upload README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-retry retry.tar;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --nowait README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pytest -xv;

--- a/pacifica/cli/__main__.py
+++ b/pacifica/cli/__main__.py
@@ -83,6 +83,10 @@ def main():
         help='Don\'t upload, stop after query engine.', required=False
     )
     upload_parser.add_argument(
+        '--do-not-upload', default=False, action='store_true', dest='do_not_upload',
+        help='Don\'t upload, works well with local save option.', required=False
+    )
+    upload_parser.add_argument(
         '--interactive', default=False, action='store_true', dest='interactive',
         help='Interact with the query engine.', required=False
     )

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -56,6 +56,7 @@ $COV_RUN -a -m pacifica.cli upload README.md
 $COV_RUN -a -m pacifica.cli upload travis
 $COV_RUN -a -m pacifica.cli upload --tar-in-tar README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar README.md
+$COV_RUN -a -m pacifica.cli upload --local-save retry.tar --do-not-upload README.md
 $COV_RUN -a -m pacifica.cli upload --local-retry retry.tar
 $COV_RUN -a -m pacifica.cli upload --nowait README.md
 


### PR DESCRIPTION
### Description

This option is useful coupled with the local-save option and will
generate an upload tar without trying to actually upload anything.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
