### PR TITLE
add the readthedocs config

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+  image: latest
+python:
+  version: 3.6
+  pip_install: true


### PR DESCRIPTION
### Description

This adds a readthedocs config to use pip install instead of setup.py.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
