### PR TITLE
Add validation url for python uploader library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pacifica CLI Uploader
 
+[![PyPi](https://img.shields.io/pypi/v/pacifica-cli.svg)]
+[![Read the Docs](https://readthedocs.org/projects/pacifica-cli/badge/?version=latest)]
 [![Build Status](https://travis-ci.org/pacifica/pacifica-cli.svg?branch=master)](https://travis-ci.org/pacifica/pacifica-cli)
 [![Build Status](https://ci.appveyor.com/api/projects/status/0ddinx1bdfroptf7?svg=true)](https://ci.appveyor.com/project/dmlb2000/pacifica-cli)
 [![Code Climate](https://codeclimate.com/github/pacifica/pacifica-cli/badges/gpa.svg)](https://codeclimate.com/github/pacifica/pacifica-cli)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ before_test:
     Start-Process C:\pacifica\Scripts\pacifica-archiveinterface.exe;
     $env:UNIQUEID_CONFIG = "$PWD/travis/uniqueid/config.cfg";
     $env:UNIQUEID_CPCONFIG = "$PWD/travis/uniqueid/server.conf";
+    pacifica-uniqueid-cmd dbsync;
     Start-Process C:\pacifica\Scripts\pacifica-uniqueid.exe;
     $env:CARTD_CONFIG = "$PWD/travis/cartd/config.cfg";
     $env:CARTD_CPCONFIG = "$PWD/travis/cartd/server.conf";
@@ -46,6 +47,7 @@ before_test:
     Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.cartd.tasks worker --loglevel=info -P solo -c 1" -RedirectStandardOutput ccelery-output.log -RedirectStandardError ccelery-error.log;
     $env:INGEST_CONFIG = "$PWD/travis/ingest/config.cfg";
     $env:INGEST_CPCONFIG = "$PWD/travis/ingest/server.conf";
+    pacifica-ingest-cmd dbsync;
     Start-Process C:\pacifica\Scripts\pacifica-ingest.exe;
     Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.ingest.tasks worker --loglevel=info -P solo -c 1" -RedirectStandardOutput celery-output.log -RedirectStandardError celery-error.log;
     $MD_VERSION = `pip show pacifica-metadata | grep Version: | awk '{ print $2 }';
@@ -100,10 +102,10 @@ test_script:
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --help;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli download --help;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure --help;
-    printf '\n\n\n\n\n\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
-    printf '\n\n\n\n\nTrue\nclientssl\n~/.pacifica-cli/my.key\n~/.pacifica-cli/my.cert\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
-    printf '\n\n\n\n\nFalse\nbasic\nusername\npassword\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
-    printf 'http://localhost:8066/upload\nhttp://localhost:8066/get_state\nhttp://localhost:8181/uploader\nhttp://localhost:8081\nhttp://localhost:8181/status/transactions/by_id\nTrue\nNone\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
+    printf '\n\n\n\n\n\n\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
+    printf '\n\n\n\n\n\nTrue\nclientssl\n~/.pacifica-cli/my.key\n~/.pacifica-cli/my.cert\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
+    printf '\n\n\n\n\n\nFalse\nbasic\nusername\npassword\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
+    printf 'http://localhost:8066/upload\nhttp://localhost:8066/get_state\nhttp://localhost:8181/uploader\nhttp://localhost:8181/ingest\nhttp://localhost:8081\nhttp://localhost:8181/status/transactions/by_id\nTrue\nNone\n' | coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli configure;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli download --transaction-id 67;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli download --cloudevent ce_stub.json;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --dry-run --instrument 54 --logon dmlb2001;

--- a/config/example.ini
+++ b/config/example.ini
@@ -21,6 +21,11 @@
 ;
 ; upload_policy_url =
 
+; Policy service external endpoint url for validation.
+; (https://policy.example.com/ingest)
+;
+; upload_validation_url =
+
 ; Cart service external endpoint url for the download.
 ; (https://cartd.example.com/
 ;

--- a/docs/_static/example.ini
+++ b/docs/_static/example.ini
@@ -21,6 +21,11 @@
 ;
 ; upload_policy_url =
 
+; Policy service external endpoint url for validation.
+; (https://policy.example.com/ingest)
+;
+; upload_validation_url =
+
 ; Cart service external endpoint url for the download.
 ; (https://cartd.example.com/
 ;

--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -18,6 +18,7 @@ What are the endpoint URLs for the following...
 Upload URL (https://ingest.example.com/upload):
 Upload Status URL (https://ingest.example.com/get_state):
 Upload Policy URL (https://policy.example.com/uploader):
+Upload Validation URL (https://policy.example.com/ingest):
 Download URL (https://cartd.example.com):
 Download Policy URL (https://policy.example.com/status/transactions/by_id):
 

--- a/pacifica/cli/configure.py
+++ b/pacifica/cli/configure.py
@@ -19,7 +19,7 @@ are designed for an uploader to interact with.
 
 What are the endpoint URLs for the following...
 """)
-    for endpnt in ['upload', 'upload_status', 'upload_policy', 'download', 'download_policy']:
+    for endpnt in ['upload', 'upload_status', 'upload_policy', 'upload_validation', 'download', 'download_policy']:
         default_url = global_ini.get('endpoints', '{}_url'.format(endpnt))
         endpnt_nice = ' '.join([
             part.capitalize() for part in endpnt.split('_')

--- a/pacifica/cli/methods.py
+++ b/pacifica/cli/methods.py
@@ -43,7 +43,10 @@ def save_user_config(global_ini):
 
 def set_environment_vars(global_ini):
     """Set some environment variables to be used later."""
-    environ['POLICY_URL'] = global_ini.get('endpoints', 'upload_policy_url')
+    environ['POLICY_UPLOADER_URL'] = global_ini.get(
+        'endpoints', 'upload_policy_url')
+    environ['POLICY_INGEST_URL'] = global_ini.get(
+        'endpoints', 'upload_validation_url')
     environ['INGEST_UPLOAD_URL'] = global_ini.get('endpoints', 'upload_url')
     environ['INGEST_STATUS_URL'] = global_ini.get(
         'endpoints', 'upload_status_url')
@@ -63,6 +66,8 @@ def generate_global_config():
                    'https://ingest.example.com/get_state')
     global_ini.set('endpoints', 'upload_policy_url',
                    'https://policy.example.com/uploader')
+    global_ini.set('endpoints', 'upload_validation_url',
+                   'https://policy.example.com/ingest')
     global_ini.set('endpoints', 'download_url',
                    'https://cartd.example.com')
     global_ini.set('endpoints', 'download_policy_url',

--- a/travis/before-install.sh
+++ b/travis/before-install.sh
@@ -12,6 +12,7 @@ pacifica-archiveinterface &
 echo $! > archiveinterface.pid
 export UNIQUEID_CONFIG="$PWD/travis/uniqueid/config.cfg"
 export UNIQUEID_CPCONFIG="$PWD/travis/uniqueid/server.conf"
+pacifica-uniqueid-cmd dbsync
 pacifica-uniqueid &
 echo $! > uniqueid.pid
 export CARTD_CONFIG="$PWD/travis/cartd/config.cfg"
@@ -23,6 +24,7 @@ celery -A pacifica.cartd.tasks worker --loglevel=info &
 echo $! > cartd.pid
 export INGEST_CONFIG="$PWD/travis/ingest/config.cfg"
 export INGEST_CPCONFIG="$PWD/travis/ingest/server.conf"
+pacifica-ingest-cmd dbsync
 pacifica-ingest &
 echo $! > ingest.pid
 celery -A pacifica.ingest.tasks worker --loglevel=info &

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -22,15 +22,15 @@ $COV_RUN -a -m pacifica.cli configure --help
 # Configure commands
 ############################
 yes | $COV_RUN -a -m pacifica.cli configure
-printf '\n\n\n\n\nTrue\nclientssl\n~/.pacifica-cli/my.key\n~/.pacifica-cli/my.cert\n' |
+printf '\n\n\n\n\n\nTrue\nclientssl\n~/.pacifica-cli/my.key\n~/.pacifica-cli/my.cert\n' |
 $COV_RUN -a -m pacifica.cli configure
-printf '\n\n\n\n\nFalse\nbasic\nusername\npassword\n' |
+printf '\n\n\n\n\n\nFalse\nbasic\nusername\npassword\n' |
 $COV_RUN -a -m pacifica.cli configure
 
 ############################
 # Build testing config
 ############################
-printf 'http://localhost:8066/upload\nhttp://localhost:8066/get_state\nhttp://localhost:8181/uploader\nhttp://localhost:8081\nhttp://localhost:8181/status/transactions/by_id\nTrue\nNone\n' |
+printf 'http://localhost:8066/upload\nhttp://localhost:8066/get_state\nhttp://localhost:8181/uploader\nhttp://localhost:8181/ingest\nhttp://localhost:8081\nhttp://localhost:8181/status/transactions/by_id\nTrue\nNone\n' |
 python -m pacifica.cli configure
 
 ############################


### PR DESCRIPTION
### Description

This adds a validation url as well as the policy query url to
allow the upload library to talk to the right configured policy
host.

Signed-off-by: David Brown <dmlb2000@gmail.com>




### Issues Resolved
Fixes #14


### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
