### PR TITLE
The return on a flush should be bytearray

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,6 +86,7 @@ install:
     python -m pip install pip setuptools wheel --upgrade;
     pip install -r requirements-dev.txt;
     pip install celery[redis] 'redis<3.0';
+    echo "Done";
 
 build: off
 

--- a/pacifica/cli/utils.py
+++ b/pacifica/cli/utils.py
@@ -53,6 +53,6 @@ def compressor_generator(compressor_type):
         def flush(self):
             """Flush the data internally if required."""
             if self._flush_passthru:
-                return ''
+                return bytearray()
             return self._comp.flush()
     return Compressor()


### PR DESCRIPTION
### Description

The return of a flush with transparent compressor should be empty `bytearray()`

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #32 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
