### PR TITLE
Fix the documentation link

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,6 @@ system level or changed on the command line by the `--config` option.
 
 The contents of the metadata configuration file is complex and should
 be read from
-[here](https://github.com/pacifica/pacifica-python-uploader/blob/master/METADATA_CONFIGURATION.md).
+[here](https://pacifica-uploader.readthedocs.io/en/latest/metadataconfig.html).
 Please get your systems administrator to help create this file for you.
 An example to start from is [here](_static/uploader.json).


### PR DESCRIPTION
### Description
This fixes the documentation link to the uploader metadata
configuration documentation in Read the Docs.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #26 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
