### PR TITLE
Fix #51 Remove Query Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ target/
 
 # GNU Dia
 *.dia~
+
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
+dist: xenial
 services:
 - postgresql
-- rabbitmq
 - redis-server
 language: python
 stages:
@@ -63,8 +63,8 @@ jobs:
     - |
       docker-compose exec metadataserver /bin/bash -c 'cd /usr/src/app/tests; python test_files/loadit_test.py';
       curl http://127.0.0.1:8181/status/users/search/dmlb2001/simple;
-      docker run -t --rm --network=pacificacli_default pacifica/cli upload --logon 10 tests;
-      docker run -t --rm --network=pacificacli_default pacifica/cli download --transaction-id 1 --destination /tmp/foo;
+      docker run -t --rm --network=pacifica-cli_default pacifica/cli upload --logon 10 tests;
+      docker run -t --rm --network=pacifica-cli_default pacifica/cli download --transaction-id 1 --destination /tmp/foo;
   - stage: deploy
     services: []
     language: python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,8 @@ before_test:
 - ps: >
     $env:PATH = "${env:PGSQL_PATH}\bin;${env:PATH}";
     createdb pacifica_metadata;
+    createdb pacifica_ingest;
+    createdb pacifica_cartd;
     C:\pacifica\Scripts\activate.ps1;
     mkdir C:\ingest;
     mkdir C:\archive;
@@ -40,12 +42,12 @@ before_test:
     $env:UNIQUEID_CPCONFIG = "$PWD/travis/uniqueid/server.conf";
     pacifica-uniqueid-cmd dbsync;
     Start-Process C:\pacifica\Scripts\pacifica-uniqueid.exe;
-    $env:CARTD_CONFIG = "$PWD/travis/cartd/config.cfg";
+    $env:CARTD_CONFIG = "$PWD/travis/cartd/config-appveyor.cfg";
     $env:CARTD_CPCONFIG = "$PWD/travis/cartd/server.conf";
     pacifica-cartd-cmd dbsync;
     Start-Process C:\pacifica\Scripts\pacifica-cartd.exe;
     Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.cartd.tasks worker --loglevel=info -P solo -c 1" -RedirectStandardOutput ccelery-output.log -RedirectStandardError ccelery-error.log;
-    $env:INGEST_CONFIG = "$PWD/travis/ingest/config.cfg";
+    $env:INGEST_CONFIG = "$PWD/travis/ingest/config-appveyor.cfg";
     $env:INGEST_CPCONFIG = "$PWD/travis/ingest/server.conf";
     pacifica-ingest-cmd dbsync;
     Start-Process C:\pacifica\Scripts\pacifica-ingest.exe;

--- a/travis/before-install.sh
+++ b/travis/before-install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -xe
 pip install -r requirements-dev.txt
 psql -c 'create database pacifica_metadata;' -U postgres
+psql -c 'create database pacifica_ingest;' -U postgres
+psql -c 'create database pacifica_cartd;' -U postgres
 export PEEWEE_URL="postgres://postgres:@127.0.0.1:5432/pacifica_metadata"
 export METADATA_CPCONFIG="$PWD/travis/metadata/server.conf"
 pacifica-metadata-cmd dbsync
@@ -15,14 +17,14 @@ export UNIQUEID_CPCONFIG="$PWD/travis/uniqueid/server.conf"
 pacifica-uniqueid-cmd dbsync
 pacifica-uniqueid &
 echo $! > uniqueid.pid
-export CARTD_CONFIG="$PWD/travis/cartd/config.cfg"
+export CARTD_CONFIG="$PWD/travis/cartd/config-travis.cfg"
 export CARTD_CPCONFIG="$PWD/travis/cartd/server.conf"
 pacifica-cartd-cmd dbsync
 pacifica-cartd &
 echo $! > cart.pid
 celery -A pacifica.cartd.tasks worker --loglevel=info &
 echo $! > cartd.pid
-export INGEST_CONFIG="$PWD/travis/ingest/config.cfg"
+export INGEST_CONFIG="$PWD/travis/ingest/config-travis.cfg"
 export INGEST_CPCONFIG="$PWD/travis/ingest/server.conf"
 pacifica-ingest-cmd dbsync
 pacifica-ingest &

--- a/travis/cartd/config-appveyor.cfg
+++ b/travis/cartd/config-appveyor.cfg
@@ -1,5 +1,5 @@
 [database]
-peewee_url = sqliteext:///db.sqlite3
+peewee_url = postgres://postgres:Password12!@localhost/pacifica_cartd
 [celery]
 broker_url = redis://127.0.0.1:6379/1
 backend_url = rpc://

--- a/travis/cartd/config-travis.cfg
+++ b/travis/cartd/config-travis.cfg
@@ -1,0 +1,5 @@
+[database]
+peewee_url = postgres://postgres:@127.0.0.1:5432/pacifica_cartd
+[celery]
+broker_url = redis://127.0.0.1:6379/1
+backend_url = rpc://

--- a/travis/check_metadata_test.py
+++ b/travis/check_metadata_test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Check the metadata for right metadata but not more."""
+import json
+import unittest
+
+
+class MetadataContentTest(unittest.TestCase):
+    """Test the metadata content."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Read the content of the metadata file and save it."""
+        with open('metadata.txt', 'r') as md_fd:
+            cls.meta = json.loads(md_fd.read())
+
+    def test_query_results(self):
+        """Test the json for query results that we've selected and nothing more."""
+        for query_obj in self.meta:
+            if query_obj['destinationTable'] == 'Files':
+                continue
+            self.assertEqual(len(query_obj['query_results']), 1, 'Length of query results should only be one value.')
+            self.assertEqual(query_obj['query_results'][0][query_obj['valueField']],
+                             query_obj['value'], 'Value of the query results should be the one we picked')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/travis/ingest/config-appveyor.cfg
+++ b/travis/ingest/config-appveyor.cfg
@@ -1,0 +1,5 @@
+[database]
+peewee_url = postgres://postgres:Password12!@localhost/pacifica_ingest
+[celery]
+broker_url = redis://127.0.0.1:6379/0
+backend_url = rpc://

--- a/travis/ingest/config-travis.cfg
+++ b/travis/ingest/config-travis.cfg
@@ -1,0 +1,5 @@
+[database]
+peewee_url = postgres://postgres:@127.0.0.1:5432/pacifica_ingest
+[celery]
+broker_url = redis://127.0.0.1:6379/0
+backend_url = rpc://

--- a/travis/ingest/config.cfg
+++ b/travis/ingest/config.cfg
@@ -1,2 +1,0 @@
-[database]
-peewee_url = sqliteext:///db.sqlite3

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -71,6 +71,8 @@ $COV_RUN -a -m pacifica.cli upload README.md
 $COV_RUN -a -m pacifica.cli upload travis
 $COV_RUN -a -m pacifica.cli upload --tar-in-tar README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar README.md
+tar -xf retry.tar metadata.txt
+python travis/check_metadata_test.py
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar --local-compress bzip2 README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar --local-compress gzip README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar --do-not-upload README.md


### PR DESCRIPTION
### Description

This removes the query results before `query_main()` returns so
that the results do not get passed along to the upload process.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #51 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
