### PR TITLE
Add Kerberos (GSSAPI) Authentication Method

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -139,10 +139,11 @@ test_script:
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload travis;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --tar-in-tar README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-save retry.tar README.md;
+    tar -xf retry.tar metadata.txt;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-save retry.tar --local-compress bzip2 README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-save retry.tar --local-compress gzip README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-save retry.tar --do-not-upload README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --local-retry retry.tar;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --nowait README.md;
-    coverage run --include='*/site-packages/pacifica/cli/*' -a -m pytest -xv;
+    coverage run --include='*/site-packages/pacifica/cli/*' -a -m pytest -xsv;
     coverage report --show-missing --fail-under 100

--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -37,6 +37,7 @@ There are three kinds of authentication types supported.
 
 - clientssl - This is where you have an SSL client key and cert
 - basic     - This is a username and password
+- gssapi    - Use GSSAPI tickets to authenticate
 - None      - Do not perform any authentication
 
 Authentication Type (None): basic

--- a/pacifica/cli/configure.py
+++ b/pacifica/cli/configure.py
@@ -81,13 +81,14 @@ There are three kinds of authentication types supported.
 
 - clientssl - This is where you have an SSL client key and cert
 - basic     - This is a username and password
+- gssapi    - Use GSSAPI tickets to authenticate
 - None      - Do not perform any authentication
 """)
     default_auth_type = global_ini.get('authentication', 'type')
     stdout.write('Authentication Type ({}): '.format(default_auth_type))
     stdout.flush()
     strip_input = stdin.readline().strip()
-    if strip_input and strip_input in ['clientssl', 'basic', 'None']:
+    if strip_input and strip_input in ['clientssl', 'basic', 'gssapi', 'None']:
         global_ini.set('authentication', 'type', strip_input)
     auth_type = global_ini.get('authentication', 'type')
     if auth_type == 'clientssl':

--- a/pacifica/cli/methods.py
+++ b/pacifica/cli/methods.py
@@ -7,6 +7,7 @@ from configparser import ConfigParser
 from getpass import getuser
 from os import environ, getenv
 from os.path import isfile
+import warnings
 from json import loads
 import requests
 from pacifica.uploader.uploader import LOGGER as UP_LOGGER
@@ -141,6 +142,17 @@ def generate_requests_auth(global_ini):
                 global_ini.get('authentication', 'cert'),
                 global_ini.get('authentication', 'key')
             )
+        }
+    elif auth_type == 'gssapi':  # pragma: no cover don't have kerberos available to test with
+        # pylint: disable=import-outside-toplevel
+        try:
+            from requests_gssapi import HTTPSPNEGOAuth
+        except ImportError as ex:
+            warnings.warn('Unable to import requests_gssapi please `pip install requests_gssapi`')
+            raise ex
+        # pylint: enable=import-outside-toplevel
+        ret = {
+            'auth': HTTPSPNEGOAuth()
         }
     elif auth_type == 'basic':
         ret = {

--- a/tests/methods_test.py
+++ b/tests/methods_test.py
@@ -50,6 +50,10 @@ class TestMethods(TestCase):
             self.assertTrue(generate_requests_auth(conf)
                             ['auth'][0], 'username')
             self.assertTrue(generate_requests_auth(conf)['auth'], 'password')
+        with ConfigClient('gssapi') as conf:
+            with self.assertRaises(ImportError) as excinfo:
+                generate_requests_auth(conf)
+            self.assertTrue('No module named' in excinfo.exception.msg)
 
     def test_verify_type(self):
         """Test the verify_type method to cover everything."""

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -77,7 +77,6 @@ $COV_RUN -a -m pacifica.cli upload travis
 $COV_RUN -a -m pacifica.cli upload --tar-in-tar README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar README.md
 tar -xf retry.tar metadata.txt
-python travis/check_metadata_test.py
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar --local-compress bzip2 README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar --local-compress gzip README.md
 $COV_RUN -a -m pacifica.cli upload --local-save retry.tar --do-not-upload README.md
@@ -92,6 +91,6 @@ unset AUTHENTICATION_PASSWORD
 ############################
 # PyTest coverage
 ############################
-$COV_RUN -a -m pytest -v
+$COV_RUN -a -m pytest -xsv
 
 coverage report --show-missing --fail-under 100


### PR DESCRIPTION
### Description

This adds GSSAPI as an authentication method for using keytabs and
Kerberos SSO to authenticate against the core endpoints.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix https://github.com/pacifica/pacifica-python-uploader/issues/36

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
