### PR TITLE
Fix #61 Do not save config during global read

### DIFF
--- a/pacifica/cli/methods.py
+++ b/pacifica/cli/methods.py
@@ -111,9 +111,6 @@ def generate_global_config():
         global_ini.read(system_config)
     if isfile(user_config):
         global_ini.read(user_config)
-    else:
-        print('Generating New Configuration.')
-    save_user_config(global_ini)
     set_environment_vars(global_ini)
     return global_ini
 


### PR DESCRIPTION

### Description
This removes the save during the global configparser object
creation. The save should only happen during a
`pacifica-cli configure` command.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #61 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
