### PR TITLE
Fix #53 Add Env Var and CLI Switch for config.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_script:
     curl -X POST -H 'content-type: application/json' -T /tmp/file-104-update.json 'http://localhost:8121/files?_id=103'
     curl -X POST -H 'content-type: application/json' -T /tmp/file-104-update.json 'http://localhost:8121/files?_id=104'
   - python tests/generate_ce_stub_test.py
+  - pip install 'redis<3.4'
+  - for x in ingest cartd notify ; do for y in frontend backend; do sudo systemctl restart ${x}_${y}.service; done ; done
 install:
 - pip install -r requirements-dev.txt
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,6 @@ install:
     C:\pacifica\Scripts\activate.ps1;
     python -m pip install pip setuptools wheel --upgrade;
     pip install -r requirements-dev.txt;
-    pip install celery[redis] 'redis';
     echo "Done";
 
 build: off
@@ -94,6 +93,7 @@ build: off
 test_script:
 - ps: >
     C:\pacifica\Scripts\activate.ps1;
+    $home_var = `python -c "from os.path import expanduser; print(expanduser('~'))";
     pip install .;
     cd tests;
     cp -r ../travis .;
@@ -135,6 +135,7 @@ test_script:
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --dry-run --logon dmlb2001 --project-regex 'expired closed and end';
     Invoke-WebRequest -Method POST -Headers @{ "content-type" = "application/json" } -Body '{ "network_id":"appveyor" }' http://localhost:8121/users?_id=10;
     Invoke-WebRequest -Method POST -Headers @{ "content-type" = "application/json" } -Body '{ "network_id":"someoneelse" }' http://localhost:8121/users?_id=11;
+    $env:PACIFICA_CLI_INI = "$home_var\.pacifica_cli\config.ini";
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload README.md;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload travis;
     coverage run --include='*/site-packages/pacifica/cli/*' -a -m pacifica.cli upload --tar-in-tar README.md;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,12 @@ The user configuration is processed second, if found. The directory the
 client looks in by default is `~/.pacifica_cli/config.ini`. The `~`
 translates to the users home directory on any platform.
 
+Optionally, users can manage their config files in their home directory
+and set the `--config-ini` command-line argument. This switch will
+try to open the given file in `~/.pacifica_cli/` and merge it with
+the system configurations. Also, setting the environment variable
+`PACIFICA_CLI_INI` can also be sufficient to change the file name.
+
 ## System Metadata
 
 The metadata is managed by a JSON configuration file referenced by an

--- a/pacifica/cli/__main__.py
+++ b/pacifica/cli/__main__.py
@@ -87,6 +87,10 @@ def main():
         help='Upload configuration metadata.', required=False
     )
     parser.add_argument(
+        '--config-ini', dest='config_ini', default=getenv('PACIFICA_CLI_INI', 'config.ini'),
+        help='Endpoint configuration ini file.', required=False
+    )
+    parser.add_argument(
         '--verbose', dest='verbose', default='info',
         help='Enable verbose logging.', required=False
     )

--- a/pacifica/cli/methods.py
+++ b/pacifica/cli/methods.py
@@ -50,9 +50,9 @@ def set_environment_vars(global_ini):
         'endpoints', 'upload_status_url')
 
 
-def generate_global_config():
+def generate_global_config(config_ini='config.ini'):
     """Generate a default configuration."""
-    user_config = user_config_path('config.ini')
+    user_config = user_config_path(config_ini)
     system_config = system_config_path('config.ini')
     global_ini = ConfigParser()
     global_ini.add_section('globals')
@@ -167,7 +167,7 @@ def generate_requests_auth(global_ini):
 def download(args, _interface_data):
     """Download data specified in args."""
     set_verbose(args.verbose)
-    global_ini = generate_global_config()
+    global_ini = generate_global_config(args.config_ini)
     auth = generate_requests_auth(global_ini)
     dl_obj = Downloader(
         cart_api_url=global_ini.get('endpoints', 'download_url'),
@@ -190,7 +190,7 @@ def upload(args, interface_data):
 def query(args, interface_data):
     """Query from the metadata configuration."""
     set_verbose(args.verbose)
-    global_ini = generate_global_config()
+    global_ini = generate_global_config(args.config_ini)
     auth = generate_requests_auth(global_ini)
     user_name = getattr(args, 'logon', None)
     if not user_name:
@@ -200,9 +200,9 @@ def query(args, interface_data):
     return query_main(md_update, args)
 
 
-def configure(_args, _config_data):
+def configure(args, _config_data):
     """Configure the client by parsing current configuration."""
-    global_ini = generate_global_config()
+    global_ini = generate_global_config(args.config_ini)
     configure_url_endpoints(global_ini)
     configure_ca_bundle(global_ini)
     configure_auth(global_ini)

--- a/pacifica/cli/utils.py
+++ b/pacifica/cli/utils.py
@@ -3,7 +3,7 @@
 """Utilities module for common methods."""
 import sys
 from os import makedirs, sep
-from os.path import expanduser, join, isdir, isfile
+from os.path import expanduser, join, isdir, isfile, isabs
 from bz2 import BZ2Compressor
 from zlib import compress
 
@@ -19,6 +19,8 @@ def system_config_path(config_file):
 
 def user_config_path(config_file):
     """Return the global configuration path."""
+    if isabs(config_file):
+        return config_file
     home = expanduser('~')
     pacifica_local_state = join(home, '.pacifica_cli')
     if not isdir(pacifica_local_state):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ pylint
 pytest
 radon
 recommonmark
+redis<3.4

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -72,6 +72,7 @@ $COV_RUN -a -m pacifica.cli upload --dry-run --logon dmlb2001 --project-regex 'e
 ############################
 curl -X POST -H 'content-type: application/json' 'localhost:8121/users?_id=10' -d'{ "network_id": "'`whoami`'"}'
 curl -X POST -H 'content-type: application/json' 'localhost:8121/users?_id=11' -d'{ "network_id": "someoneelse"}'
+export PACIFICA_CLI_INI="/home/travis/.pacifica_cli/config.ini"
 $COV_RUN -a -m pacifica.cli upload README.md
 $COV_RUN -a -m pacifica.cli upload travis
 $COV_RUN -a -m pacifica.cli upload --tar-in-tar README.md


### PR DESCRIPTION
### Description

This adds an environment variable `PACIFICA_CLI_INI` and
commandline switch `--config-ini` to set the endpoints
configuration path in the users home directory.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #53 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
