### PR TITLE
Fix #56 Resolve Logon User Always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,8 @@ services:
     - archiveinterface:archivei
     volumes:
     - cartddata:/shared
+    ports:
+    - 8081:8081
     environment:
       PEEWEE_ADDR: mysql
       BROKER_URL: pyamqp://guest:guest@amqp:5672//

--- a/pacifica/cli/query.py
+++ b/pacifica/cli/query.py
@@ -171,7 +171,7 @@ def query_main(md_update, args):
             regex = '.*'
         filter_results(md_update, query_obj, regex)
         default_id = getattr(args, query_obj.metaID, None)
-        if not default_id:
+        if not default_id or query_obj.metaID == 'logon':
             default_id = md_update[query_obj.metaID].value
         set_results(
             md_update,


### PR DESCRIPTION
### Description

The logon user is special and maybe the network name when placed
on the command line. So we should always resolve it to and ID as
that's the internal representation we manage.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #56 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
