### PR TITLE
Add Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,21 @@ jobs:
     script:
     - pre-commit run -a
     - radon cc pacifica
+  - python: 3.7
+    before_script: skip
+    script:
+    - pre-commit run -a
+    - radon cc pacifica
+  - python: 3.8
+    before_script: skip
+    script:
+    - pre-commit run -a
+    - radon cc pacifica
   - stage: test
+  - python: 3.7
+  - python: 3.8
   - stage: test-docker
+    python: 3.8
     before_script: skip
     sudo: required
     services:
@@ -63,6 +76,7 @@ jobs:
       docker run -t --rm --network=pacifica-cli_default pacifica/cli download --transaction-id 1 --destination /tmp/foo;
   - stage: deploy
     before_script: skip
+    python: 3.8
     script: skip
     deploy:
       skip_cleanup: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
 
   matrix:
     - PYTHON: C:\Python36-x64
+    - PYTHON: C:\Python37-x64
+    - PYTHON: C:\Python38-x64
 
 services:
   - postgresql


### PR DESCRIPTION
### Description

This adds Python 3.7 and 3.8 to Appveyor and Travis CI testing.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
